### PR TITLE
Feat/8.naive.resize

### DIFF
--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -euo pipefail
+just pre-commit

--- a/.git-hooks/pre-push
+++ b/.git-hooks/pre-push
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+
+just pre-push

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ WIOT aims to become a universal toolkit to:
 - Process images in real-time or in batch
 - Support multiple entrypoints: CLI, HTTP, AWS Lambda, GCP, etc.
 - Handle multiple sources/destinations: local files, HTTP, S3, etc.
-- Be easily embeddable, composable, and cloud-native
+- Offer a clear, composable API for transformations via `ProcessingOptions`
 
 ---
 
@@ -26,9 +26,11 @@ WIOT aims to become a universal toolkit to:
 
 The CLI currently supports:
 
-- ✅ Basic pipeline execution: read → process (noop) → write
+- ✅ Basic pipeline execution: read → process → write
+- ✅ Image loaded into stateful pipeline
+- ✅ Modular processing steps (resize, encoding, etc.)
 - ✅ Automatic adapter resolution for local paths
-- ✅ Clean core-adapter architecture with extensibility in mind
+- 🧪 Early support for resize options (via ProcessingOptions)
 
 ---
 
@@ -42,7 +44,7 @@ The CLI currently supports:
 |               | Save image                      | ✅ Done        |
 |               | Output Format detection         | ✅ Done        |
 |               | Automatic format selection      | 🧪 Planned     |
-|               | Resize (width & height)         | 🧪 Planned     |
+|               | Resize (width & height)         | 🔧 In progress     |
 |               | Resize (DPI)                    | 🧪 Planned     |
 |               | Resize Aspect Ratio Strategy    | 🧪 Planned     |
 |               | Resize Cover Strategy           | 🧪 Planned     |
@@ -90,8 +92,9 @@ cargo run -p cli -- --input ./image.jpg --output ./output.jpg
 ```
 
 Supported input/output formats:
-- ✅ Local paths (`./image.jpg`, `file://...`)
-- 🔧 HTTP URLs, S3 paths — coming soon
+- ✅ Local file paths (`./image.jpg`, `file://...`)
+- 🔧 HTTP URLs (`https://...`)
+- 🔧 S3 paths (`s3://bucket/key.jpg`)
 
 ---
 
@@ -103,10 +106,54 @@ Supported input/output formats:
 
 ---
 
+## 🧱 Architecture
+
+```
+wiot-image-optimizer/
+├── core/                  # Business logic: image pipeline, processing options
+│   └── src/
+│       ├── lib.rs         # Entry point for the pipeline
+│       ├── models/        # Option models (resize, format, quality, etc.)
+│       └── services/      # Logic to apply those options (resize.rs, encode.rs, etc.)
+│
+├── adapters/              # FileSource & FileDestination implementations
+│   ├── local.rs           # Local filesystem adapter
+│   └── (http|s3|...)      # Future adapters
+│
+├── entrypoints/           # How users interact with WIOT
+│   └── cli/               # CLI entrypoint (args parsing, triggering pipeline)
+│   └── (http/aws/gcp/...)# Future interfaces
+│
+├── tests/                 # Integration and E2E tests
+│
+└── scripts/               # Dev tooling (Justfile, Dockerfile, etc.)
+```
+
+---
+
 ## 🤝 Contributing
 
 We’re building the foundation — your help is welcome!
 If you're interested in adapters, pipeline logic, format support, or CLI design, check out the issues and the [contribution guide](link-to-contribution-guidelines).
+
+---
+
+### 🛠 Project Setup
+
+After cloning the repository, run:
+
+```bash
+just install
+```
+
+This will:
+
+- Install required tools (`rustfmt`, `cargo-tarpaulin`, etc.)
+- Set up Git hooks to enforce formatting, linting, and testing before commit/push
+- Prepare your local dev environment
+
+> 💡 If you don’t have [`just`](https://github.com/casey/just) installed yet, do:
+> `cargo install just`
 
 ---
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2024"
 anyhow = "1.0.97"
 async-trait = "0.1.88"
 image = "0.25.6"
-tokio = { version = "1.44.1", features = ["fs"] }
+tokio = { version = "1.44.1", features = ["fs", "macros", "rt", "rt-multi-thread"] }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,15 +1,18 @@
+pub mod models;
 pub mod services;
 
-use std::sync::Arc;
-
 use image::DynamicImage;
+use models::options::ProcessingOptions;
 use services::{io::FileDestination, io::FileSource};
+use std::sync::Arc;
 
 pub struct ImagePipeline<'a> {
     source: Arc<dyn FileSource>,
     destination: Arc<dyn FileDestination>,
     input: &'a str,
     output: &'a str,
+    options: ProcessingOptions,
+    image: Option<DynamicImage>,
 }
 
 impl<'a> ImagePipeline<'a> {
@@ -24,33 +27,40 @@ impl<'a> ImagePipeline<'a> {
             destination,
             input,
             output,
+            options: ProcessingOptions::default(),
+            image: None,
         }
     }
 
-    pub async fn run(&mut self) {
-        let image = match self.source.read(self.input).await {
-            Ok(img) => img,
-            Err(e) => {
-                eprintln!("Error reading image: {}", e);
-                return;
-            }
-        };
-
-        let processed_image = match self.process_image(image) {
-            Ok(img) => img,
-            Err(e) => {
-                eprintln!("Error processing image: {}", e);
-                return;
-            }
-        };
-
-        if let Err(e) = self.destination.write(self.output, &processed_image).await {
-            eprintln!("Error writing image: {}", e);
+    pub async fn load(&mut self) -> Result<(), anyhow::Error> {
+        self.image = Some(self.source.read(self.input).await?);
+        if self.image.is_none() {
+            return Err(anyhow::anyhow!("[core/pipeline] Image cannot be loaded"));
         }
+        Ok(())
     }
 
-    fn process_image(&self, image: DynamicImage) -> Result<DynamicImage, String> {
-        // Placeholder for image processing logic
-        Ok(image)
+    pub async fn store(&mut self) -> Result<(), anyhow::Error> {
+        self.destination
+            .write(
+                self.output,
+                self.image
+                    .as_ref()
+                    .ok_or_else(|| anyhow::anyhow!("[core/pipeline] Image cannot be loaded"))?,
+            )
+            .await?;
+        Ok(())
+    }
+
+    pub async fn run(&mut self) -> Result<(), anyhow::Error> {
+        self.load().await?;
+        self.process_image()?;
+        self.store().await?;
+        Ok(())
+    }
+
+    fn process_image(&mut self) -> Result<(), anyhow::Error> {
+        self.resize()?;
+        Ok(())
     }
 }

--- a/core/src/models/mod.rs
+++ b/core/src/models/mod.rs
@@ -1,0 +1,2 @@
+pub mod options;
+pub mod resize_options;

--- a/core/src/models/options.rs
+++ b/core/src/models/options.rs
@@ -5,14 +5,6 @@ pub struct ProcessingOptions {
     pub resize: Option<ResizeOptions>,
 }
 
-// impl Default for ProcessingOptions {
-//     fn default() -> Self {
-//         ProcessingOptions {
-//             resize: None,
-//         }
-//     }
-// }
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/core/src/models/options.rs
+++ b/core/src/models/options.rs
@@ -1,0 +1,35 @@
+pub use super::resize_options::ResizeOptions;
+
+#[derive(Debug, Default, Clone)]
+pub struct ProcessingOptions {
+    pub resize: Option<ResizeOptions>,
+}
+
+// impl Default for ProcessingOptions {
+//     fn default() -> Self {
+//         ProcessingOptions {
+//             resize: None,
+//         }
+//     }
+// }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::resize_options::ResizeOptions;
+
+    #[test]
+    fn test_default_processing_options() {
+        let options = ProcessingOptions::default();
+        assert!(options.resize.is_none());
+    }
+
+    #[test]
+    fn test_processing_options_with_resize() {
+        let resize_options = ResizeOptions::default();
+        let options = ProcessingOptions {
+            resize: Some(resize_options),
+        };
+        assert!(options.resize.is_some());
+    }
+}

--- a/core/src/models/resize_options.rs
+++ b/core/src/models/resize_options.rs
@@ -14,7 +14,7 @@ impl Default for ResizeOptions {
         Self {
             width: None,
             height: None,
-            dpr: None,
+            dpr: Some(1.0),
             filter: FilterType::Triangle,
         }
     }
@@ -42,26 +42,32 @@ impl ResizeOptions {
 
     /*
      * Validate the resize options.
-     * - Width and height must be greater than 0 if specified.
-     * - DPR must be between 0.1 and 10.0 if specified.
-     * - If both width and height are specified, they must be greater than 0.
-     * - If only one of width or height is specified, the other must be None.
-     * - If both width and height are None, the resize options are considered valid.
+     *
+     * - If width is Some, it must be > 0
+     * - If height is Some, it must be > 0
+     * - width and height can both be None or both be > 0
+     * - DPR must be between 0.1 and 10.0 (default = 1.0)
      */
     pub fn validate(&self) -> Result<(), anyhow::Error> {
-        if self.width.is_some() && self.width.unwrap() == 0 {
-            return Err(anyhow!("Resize width must be greater than 0"));
-        }
-
-        if self.height.is_some() && self.height.unwrap() == 0 {
-            return Err(anyhow!("Resize height must be greater than 0"));
-        }
-
-        if let Some(dpr) = self.dpr {
-            if !(0.1..=10.0).contains(&dpr) {
-                return Err(anyhow!("Resize dpr must be between 0.1 and 10.0"));
+        if let Some(width) = self.width {
+            if width == 0 {
+                return Err(anyhow!("Resize width must be greater than 0"));
             }
         }
+
+        if let Some(height) = self.height {
+            if height == 0 {
+                return Err(anyhow!("Resize height must be greater than 0"));
+            }
+        }
+
+        let dpr = self.dpr.unwrap_or(1.0);
+        if !(0.1..=10.0).contains(&dpr) {
+            return Err(anyhow!(
+                "Resize dpr must be between 0.1 and 10.0 (default is 1.0)"
+            ));
+        }
+
         Ok(())
     }
 }
@@ -72,93 +78,45 @@ mod tests {
 
     #[test]
     fn valid_resize_options_pass() {
-        let opts = ResizeOptions {
-            width: Some(800),
-            height: Some(600),
-            dpr: Some(2.0),
-            ..Default::default()
-        };
-
-        assert!(opts.validate().is_ok());
+        let opts = vec![
+            ResizeOptions::new(Some(800), Some(600), Some(2.0)),
+            ResizeOptions::new(None, None, None),
+            ResizeOptions::new(Some(800), None, Some(2.0)),
+            ResizeOptions::new(None, Some(600), Some(2.0)),
+        ];
+        for opt in opts {
+            assert!(opt.is_ok());
+        }
     }
 
     #[test]
-    fn valid_partial_options_pass() {
-        let opts = ResizeOptions {
-            width: Some(500),
-            height: None,
-            dpr: None,
-            ..Default::default()
-        };
-
-        assert!(opts.validate().is_ok());
+    fn invalid_resize_sizes_options_fails() {
+        let opts = vec![
+            ResizeOptions::new(Some(0), Some(100), None),
+            ResizeOptions::new(Some(0), None, Some(2.0)),
+            ResizeOptions::new(None, Some(0), Some(2.0)),
+            ResizeOptions::new(Some(100), Some(0), None),
+        ];
+        for opt in opts {
+            assert!(opt.is_err());
+        }
     }
 
     #[test]
-    fn invalid_width_zero_fails() {
-        let opts = ResizeOptions {
-            width: Some(0),
-            height: Some(100),
-            dpr: None,
-            ..Default::default()
-        };
+    fn invalid_dpr_fails() {
+        let opts = vec![
+            ResizeOptions::new(Some(100), Some(100), Some(0.0)),
+            ResizeOptions::new(Some(100), Some(100), Some(11.0)),
+            ResizeOptions::new(Some(100), Some(100), Some(0.05)),
+            ResizeOptions::new(Some(100), Some(100), Some(42.0)),
+        ];
 
-        let result = opts.validate();
-        assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err().to_string(),
-            "Resize width must be greater than 0"
-        );
-    }
-
-    #[test]
-    fn invalid_height_zero_fails() {
-        let opts = ResizeOptions {
-            width: None,
-            height: Some(0),
-            dpr: None,
-            ..Default::default()
-        };
-
-        let result = opts.validate();
-        assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err().to_string(),
-            "Resize height must be greater than 0"
-        );
-    }
-
-    #[test]
-    fn invalid_dpr_low_fails() {
-        let opts = ResizeOptions {
-            width: Some(100),
-            height: Some(100),
-            dpr: Some(0.05),
-            ..Default::default()
-        };
-
-        let result = opts.validate();
-        assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err().to_string(),
-            "Resize dpr must be between 0.1 and 10.0"
-        );
-    }
-
-    #[test]
-    fn invalid_dpr_high_fails() {
-        let opts = ResizeOptions {
-            width: Some(100),
-            height: Some(100),
-            dpr: Some(42.0),
-            ..Default::default()
-        };
-
-        let result = opts.validate();
-        assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err().to_string(),
-            "Resize dpr must be between 0.1 and 10.0"
-        );
+        for opt in opts {
+            assert!(opt.is_err());
+            assert_eq!(
+                opt.unwrap_err().to_string(),
+                "Resize dpr must be between 0.1 and 10.0 (default is 1.0)"
+            );
+        }
     }
 }

--- a/core/src/models/resize_options.rs
+++ b/core/src/models/resize_options.rs
@@ -1,0 +1,164 @@
+use anyhow::{Result, anyhow};
+use image::imageops::FilterType;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ResizeOptions {
+    pub width: Option<u32>,
+    pub height: Option<u32>,
+    pub dpr: Option<f32>,
+    pub filter: FilterType,
+}
+
+impl Default for ResizeOptions {
+    fn default() -> Self {
+        Self {
+            width: None,
+            height: None,
+            dpr: None,
+            filter: FilterType::Triangle,
+        }
+    }
+}
+
+impl ResizeOptions {
+    pub fn new(width: Option<u32>, height: Option<u32>, dpr: Option<f32>) -> Result<Self> {
+        let opts: ResizeOptions = Self {
+            width,
+            height,
+            dpr,
+            ..Self::default()
+        };
+        opts.validate()?;
+        Ok(opts)
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.width.is_some() || self.height.is_some()
+    }
+
+    pub fn effective_dpr(&self) -> f32 {
+        self.dpr.unwrap_or(1.0)
+    }
+
+    /*
+     * Validate the resize options.
+     * - Width and height must be greater than 0 if specified.
+     * - DPR must be between 0.1 and 10.0 if specified.
+     * - If both width and height are specified, they must be greater than 0.
+     * - If only one of width or height is specified, the other must be None.
+     * - If both width and height are None, the resize options are considered valid.
+     */
+    pub fn validate(&self) -> Result<(), anyhow::Error> {
+        if self.width.is_some() && self.width.unwrap() == 0 {
+            return Err(anyhow!("Resize width must be greater than 0"));
+        }
+
+        if self.height.is_some() && self.height.unwrap() == 0 {
+            return Err(anyhow!("Resize height must be greater than 0"));
+        }
+
+        if let Some(dpr) = self.dpr {
+            if !(0.1..=10.0).contains(&dpr) {
+                return Err(anyhow!("Resize dpr must be between 0.1 and 10.0"));
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_resize_options_pass() {
+        let opts = ResizeOptions {
+            width: Some(800),
+            height: Some(600),
+            dpr: Some(2.0),
+            ..Default::default()
+        };
+
+        assert!(opts.validate().is_ok());
+    }
+
+    #[test]
+    fn valid_partial_options_pass() {
+        let opts = ResizeOptions {
+            width: Some(500),
+            height: None,
+            dpr: None,
+            ..Default::default()
+        };
+
+        assert!(opts.validate().is_ok());
+    }
+
+    #[test]
+    fn invalid_width_zero_fails() {
+        let opts = ResizeOptions {
+            width: Some(0),
+            height: Some(100),
+            dpr: None,
+            ..Default::default()
+        };
+
+        let result = opts.validate();
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Resize width must be greater than 0"
+        );
+    }
+
+    #[test]
+    fn invalid_height_zero_fails() {
+        let opts = ResizeOptions {
+            width: None,
+            height: Some(0),
+            dpr: None,
+            ..Default::default()
+        };
+
+        let result = opts.validate();
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Resize height must be greater than 0"
+        );
+    }
+
+    #[test]
+    fn invalid_dpr_low_fails() {
+        let opts = ResizeOptions {
+            width: Some(100),
+            height: Some(100),
+            dpr: Some(0.05),
+            ..Default::default()
+        };
+
+        let result = opts.validate();
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Resize dpr must be between 0.1 and 10.0"
+        );
+    }
+
+    #[test]
+    fn invalid_dpr_high_fails() {
+        let opts = ResizeOptions {
+            width: Some(100),
+            height: Some(100),
+            dpr: Some(42.0),
+            ..Default::default()
+        };
+
+        let result = opts.validate();
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Resize dpr must be between 0.1 and 10.0"
+        );
+    }
+}

--- a/core/src/services/mod.rs
+++ b/core/src/services/mod.rs
@@ -1,1 +1,2 @@
 pub mod io;
+pub mod options;

--- a/core/src/services/options/mod.rs
+++ b/core/src/services/options/mod.rs
@@ -1,0 +1,1 @@
+pub mod resize;

--- a/core/src/services/options/resize.rs
+++ b/core/src/services/options/resize.rs
@@ -1,0 +1,119 @@
+use crate::ImagePipeline;
+
+impl ImagePipeline<'_> {
+    pub fn resize(&mut self) -> Result<(), anyhow::Error> {
+        if let Some(ref resize_options) = self.options.resize {
+            if resize_options.is_enabled() {
+                let image = self
+                    .image
+                    .as_mut()
+                    .ok_or_else(|| anyhow::anyhow!("[core/resize] Image cannot be loaded"))?;
+                let width = resize_options.width.unwrap_or(image.width());
+                let height = resize_options.height.unwrap_or(image.height());
+                let dpr = resize_options.effective_dpr();
+
+                // Resize the image
+                *image = image.resize(
+                    (width as f32 * dpr) as u32,
+                    (height as f32 * dpr) as u32,
+                    resize_options.filter,
+                );
+            }
+        }
+        Ok(())
+    }
+}
+#[cfg(test)]
+mod tests {
+    use crate::ImagePipeline;
+    use crate::models::options::{ProcessingOptions, ResizeOptions};
+    use crate::services::io::{FileDestination, FileSource};
+    use anyhow::Result;
+    use async_trait::async_trait;
+    use image::{DynamicImage, Rgba};
+    use std::sync::Arc;
+
+    /// Mock source that returns a 100x100 white image
+    struct MockSource;
+
+    #[async_trait]
+    impl FileSource for MockSource {
+        async fn read(&self, _path: &str) -> Result<DynamicImage> {
+            let image = DynamicImage::ImageRgba8(image::ImageBuffer::from_pixel(
+                100,
+                100,
+                Rgba([255, 255, 255, 255]),
+            ));
+            Ok(image)
+        }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    /// Mock destination that does nothing but captures the image
+    struct MockDestination;
+
+    #[async_trait]
+    impl FileDestination for MockDestination {
+        async fn write(&self, _path: &str, _image: &DynamicImage) -> Result<()> {
+            println!("Mock write to {}", _path);
+            Ok(())
+        }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    fn create_pipeline() -> ImagePipeline<'static> {
+        let source = Arc::new(MockSource);
+        let destination = Arc::new(MockDestination);
+        ImagePipeline::new(source, destination, "input", "output")
+    }
+
+    fn set_opts(pipeline: &mut ImagePipeline, width: u32, height: u32, dpr: f32) {
+        pipeline.options = ProcessingOptions {
+            resize: Some(ResizeOptions {
+                width: Some(width),
+                height: Some(height),
+                dpr: Some(dpr),
+                ..Default::default()
+            }),
+        };
+    }
+
+    async fn verify_base_image_size(pipeline: &mut ImagePipeline<'_>) {
+        pipeline.load().await.unwrap();
+        assert!(pipeline.image.is_some());
+        assert_eq!(pipeline.image.as_ref().unwrap().width(), 100);
+        assert_eq!(pipeline.image.as_ref().unwrap().height(), 100);
+    }
+
+    #[tokio::test]
+    async fn test_pipeline_resize_applies() {
+        let mut pipeline = create_pipeline();
+        set_opts(&mut pipeline, 50, 50, 1.0);
+        verify_base_image_size(&mut pipeline).await;
+
+        // Resize the image & check the size
+        pipeline.resize().unwrap();
+        assert!(pipeline.image.is_some());
+        assert_eq!(pipeline.image.as_ref().unwrap().width(), 50);
+        assert_eq!(pipeline.image.as_ref().unwrap().height(), 50);
+    }
+
+    #[tokio::test]
+    async fn test_pipeline_dpr_resize_applies() {
+        let mut pipeline = create_pipeline();
+        set_opts(&mut pipeline, 10, 10, 2.0);
+        verify_base_image_size(&mut pipeline).await;
+
+        // Resize the image & check the size (10x10 with 2.0 dpr = 20x20)
+        pipeline.resize().unwrap();
+        assert!(pipeline.image.is_some());
+        assert_eq!(pipeline.image.as_ref().unwrap().width(), 20);
+        assert_eq!(pipeline.image.as_ref().unwrap().height(), 20);
+    }
+}

--- a/core/src/services/options/resize.rs
+++ b/core/src/services/options/resize.rs
@@ -14,8 +14,8 @@ impl ImagePipeline<'_> {
 
                 // Resize the image
                 *image = image.resize(
-                    (width as f32 * dpr) as u32,
-                    (height as f32 * dpr) as u32,
+                    (width as f32 * dpr).round() as u32,
+                    (height as f32 * dpr).round() as u32,
                     resize_options.filter,
                 );
             }
@@ -115,5 +115,25 @@ mod tests {
         assert!(pipeline.image.is_some());
         assert_eq!(pipeline.image.as_ref().unwrap().width(), 20);
         assert_eq!(pipeline.image.as_ref().unwrap().height(), 20);
+    }
+
+    #[tokio::test]
+    async fn test_pipeline_dpr_resize_round_applies() {
+        let mut pipeline = create_pipeline();
+        set_opts(&mut pipeline, 10, 10, 2.04);
+        verify_base_image_size(&mut pipeline).await;
+
+        // Resize the image & check the size (10x10 with 2.04 dpr should be round to down = 20x20)
+        pipeline.resize().unwrap();
+        assert!(pipeline.image.is_some());
+        assert_eq!(pipeline.image.as_ref().unwrap().width(), 20);
+        assert_eq!(pipeline.image.as_ref().unwrap().height(), 20);
+
+        // Resize the image & check the size (10x10 with 2.05 dpr should be round to up = 21x21)
+        set_opts(&mut pipeline, 10, 10, 2.05);
+        pipeline.resize().unwrap();
+        assert!(pipeline.image.is_some());
+        assert_eq!(pipeline.image.as_ref().unwrap().width(), 21);
+        assert_eq!(pipeline.image.as_ref().unwrap().height(), 21);
     }
 }

--- a/entrypoints/cli/src/main.rs
+++ b/entrypoints/cli/src/main.rs
@@ -31,7 +31,7 @@ async fn main() -> Result<()> {
     let mut pipeline = ImagePipeline::new(source, destination, &args.input, &args.output);
 
     // Run the pipeline
-    pipeline.run().await;
+    pipeline.run().await?;
 
     Ok(())
 }

--- a/justfile
+++ b/justfile
@@ -46,7 +46,7 @@ pre-push:
 pre-commit:
     #!/bin/bash
     echo "🔧 [pre-commit] Running format..."
-    just format
+    just format ""
 
     echo "🧹 [pre-commit] Running lint --fix..."
     just lint --fix --allow-dirty --allow-staged

--- a/justfile
+++ b/justfile
@@ -4,23 +4,51 @@ default:
   just -l
 
 install:
-  rustup component add rustfmt
-  cargo install cargo-tarpaulin
+    just setup-hooks
+    rustup component add rustfmt
+    cargo install cargo-tarpaulin
 
 lint *OPTS="-- -D warnings":
-  cargo clippy {{OPTS}}
+    cargo clippy {{OPTS}}
 
 check:
-  cargo check
+    cargo check
 
 format *OPTS="--check":
-  cargo fmt {{OPTS}}
+    cargo fmt {{OPTS}}
 
 test *OPTS="--verbose":
-  cargo test {{OPTS}}
+    cargo test {{OPTS}}
 
 coverage:
-  cargo tarpaulin --verbose
+    cargo tarpaulin --verbose
 
 build:
-  cargo build --release --all-targets --all-features
+    cargo build --release --all-targets --all-features
+
+setup-hooks:
+    chmod +x .git-hooks/*
+    git config core.hooksPath .git-hooks
+
+pre-push:
+    #!/bin/bash
+    echo "🔎 [pre-push] Checking formatting..."
+    just format --check
+
+    echo "🧠 [pre-push] Running clippy..."
+    just lint -- -D warnings
+
+    echo "🧪 [pre-push] Running tests..."
+    just test --all
+
+    echo "✅ [pre-push] All checks passed."
+
+pre-commit:
+    #!/bin/bash
+    echo "🔧 [pre-commit] Running format..."
+    just format
+
+    echo "🧹 [pre-commit] Running lint --fix..."
+    just lint --fix --allow-dirty --allow-staged
+
+    echo "✅ [pre-commit] Done."


### PR DESCRIPTION
#8 
@snackoverflow215 

## ✨ Feature: Naive Resize Support in Core Pipeline

### 🧩 Context

This PR adds foundational support for **image resizing** directly in the `core` processing pipeline.

It introduces:
- A new `ResizeOptions` model (`core/src/models/`)
- A resize processing step (`core/src/services/options/resize.rs`)
- Integration into the `ImagePipeline::process_image` method

> This sets the stage for advanced resizing strategies like DPI, aspect-ratio, contain/cover/stretch later on.

---

### ✅ What’s included

- ✅ `ResizeOptions` struct with width, height, dpr, filter
- ✅ Default values and validation logic
- ✅ Resize execution in pipeline via `image.resize(...)`
- ✅ Modular organization (`models/` and `services/options/resize.rs`)
- ✅ CLI integration using automatic options (placeholder for now)
- ✅ Git hooks (`.git-hooks/`) using `just` for:
  - `pre-commit`: auto-format + clippy fix
  - `pre-push`: format check + clippy strict + tests
- ✅ Updated `Justfile` (`setup-hooks`, `lint`, etc.)
- ✅ `README.md` updated:
  - Architecture diagram
  - Setup instructions (`just install`)
  - Current status and roadmap update

---

### 🛠 Next steps

- [ ] Use CLI or config to pass resize options
- [ ] Extend resize with DPI handling
- [ ] Add aspect ratio strategies (cover, contain, fill...)
- [ ] Add integration tests

---

### 🙌 Notes

- This PR includes clean separation of concerns (options, services, pipeline)
- Validations are kept inside each option’s model (e.g. ResizeOptions::validate)
- Hooks rely only on `just`, no extra tools required
