### PR TITLE
feat(core): add DPR scaling support in resize options

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ The CLI currently supports:
 |               | Save image                      | ✅ Done        |
 |               | Output Format detection         | ✅ Done        |
 |               | Automatic format selection      | 🧪 Planned     |
-|               | Resize (width & height)         | 🔧 In progress     |
-|               | Resize (DPI)                    | 🧪 Planned     |
+|               | Resize (width & height)         | ✅ Done     |
+|               | Resize (DPI)                    | ✅ Done     |
 |               | Resize Aspect Ratio Strategy    | 🧪 Planned     |
 |               | Resize Cover Strategy           | 🧪 Planned     |
 |               | Resize Contain Strategy         | 🧪 Planned     |
@@ -84,6 +84,8 @@ The CLI currently supports:
 |               | Golden image             | 💭 Idea |
 |               | AWS Lambda Zip           | 💭 Idea |
 |               | One-click cloud deploy   | 💭 Idea |
+|               | srcset / responsive variants    | 💭 Idea        |
+
 
 ## 🚀 Getting Started
 

--- a/core/src/models/resize_options.rs
+++ b/core/src/models/resize_options.rs
@@ -33,9 +33,9 @@ impl ResizeOptions {
     }
 
     pub fn is_enabled(&self) -> bool {
-        self.width.is_some()
-            || self.height.is_some()
-            || (self.dpr.is_some() && self.dpr != Some(1.0))
+        let is_size_modified = self.width.is_some() || self.height.is_some();
+        let is_dpr_modified = matches!(self.dpr, Some(val) if val != 1.0);
+        is_size_modified || is_dpr_modified
     }
 
     /*

--- a/core/src/models/resize_options.rs
+++ b/core/src/models/resize_options.rs
@@ -33,11 +33,9 @@ impl ResizeOptions {
     }
 
     pub fn is_enabled(&self) -> bool {
-        self.width.is_some() || self.height.is_some()
-    }
-
-    pub fn effective_dpr(&self) -> f32 {
-        self.dpr.unwrap_or(1.0)
+        self.width.is_some()
+            || self.height.is_some()
+            || (self.dpr.is_some() && self.dpr != Some(1.0))
     }
 
     /*
@@ -77,46 +75,84 @@ mod tests {
     use super::*;
 
     #[test]
-    fn valid_resize_options_pass() {
-        let opts = vec![
-            ResizeOptions::new(Some(800), Some(600), Some(2.0)),
-            ResizeOptions::new(None, None, None),
-            ResizeOptions::new(Some(800), None, Some(2.0)),
-            ResizeOptions::new(None, Some(600), Some(2.0)),
-        ];
-        for opt in opts {
-            assert!(opt.is_ok());
+    fn test_default_dpr() {
+        let opts = ResizeOptions::default();
+        assert_eq!(opts.dpr, Some(1.0));
+    }
+
+    mod is_enabled {
+        use super::*;
+
+        #[test]
+        fn test_is_enabled() {
+            // Full
+            let opts = ResizeOptions::new(Some(800), Some(600), Some(2.0)).unwrap();
+            assert!(opts.is_enabled());
+
+            // None
+            let opts = ResizeOptions::new(None, None, None).unwrap();
+            assert!(!opts.is_enabled());
+
+            // Width only
+            let opts = ResizeOptions::new(Some(800), None, None).unwrap();
+            assert!(opts.is_enabled());
+
+            // Height only
+            let opts = ResizeOptions::new(None, Some(600), None).unwrap();
+            assert!(opts.is_enabled());
+
+            // DPR only != 1.0
+            let opts = ResizeOptions::new(None, None, Some(2.0)).unwrap();
+            assert!(opts.is_enabled());
         }
     }
 
-    #[test]
-    fn invalid_resize_sizes_options_fails() {
-        let opts = vec![
-            ResizeOptions::new(Some(0), Some(100), None),
-            ResizeOptions::new(Some(0), None, Some(2.0)),
-            ResizeOptions::new(None, Some(0), Some(2.0)),
-            ResizeOptions::new(Some(100), Some(0), None),
-        ];
-        for opt in opts {
-            assert!(opt.is_err());
+    mod validate {
+        use super::*;
+
+        #[test]
+        fn valid_resize_options_pass() {
+            let opts = vec![
+                ResizeOptions::new(Some(800), Some(600), Some(2.0)),
+                ResizeOptions::new(None, None, None),
+                ResizeOptions::new(Some(800), None, Some(2.0)),
+                ResizeOptions::new(None, Some(600), Some(2.0)),
+                ResizeOptions::new(None, None, Some(2.0)),
+            ];
+            for opt in opts {
+                assert!(opt.is_ok());
+            }
         }
-    }
 
-    #[test]
-    fn invalid_dpr_fails() {
-        let opts = vec![
-            ResizeOptions::new(Some(100), Some(100), Some(0.0)),
-            ResizeOptions::new(Some(100), Some(100), Some(11.0)),
-            ResizeOptions::new(Some(100), Some(100), Some(0.05)),
-            ResizeOptions::new(Some(100), Some(100), Some(42.0)),
-        ];
+        #[test]
+        fn invalid_resize_sizes_options_fails() {
+            let opts = vec![
+                ResizeOptions::new(Some(0), Some(100), None),
+                ResizeOptions::new(Some(0), None, Some(2.0)),
+                ResizeOptions::new(None, Some(0), Some(2.0)),
+                ResizeOptions::new(Some(100), Some(0), None),
+            ];
+            for opt in opts {
+                assert!(opt.is_err());
+            }
+        }
 
-        for opt in opts {
-            assert!(opt.is_err());
-            assert_eq!(
-                opt.unwrap_err().to_string(),
-                "Resize dpr must be between 0.1 and 10.0 (default is 1.0)"
-            );
+        #[test]
+        fn invalid_dpr_fails() {
+            let opts = vec![
+                ResizeOptions::new(Some(100), Some(100), Some(0.0)),
+                ResizeOptions::new(Some(100), Some(100), Some(11.0)),
+                ResizeOptions::new(Some(100), Some(100), Some(0.05)),
+                ResizeOptions::new(Some(100), Some(100), Some(42.0)),
+            ];
+
+            for opt in opts {
+                assert!(opt.is_err());
+                assert_eq!(
+                    opt.unwrap_err().to_string(),
+                    "Resize dpr must be between 0.1 and 10.0 (default is 1.0)"
+                );
+            }
         }
     }
 }

--- a/core/src/services/options/resize.rs
+++ b/core/src/services/options/resize.rs
@@ -10,7 +10,7 @@ impl ImagePipeline<'_> {
                     .ok_or_else(|| anyhow::anyhow!("[core/resize] Image cannot be loaded"))?;
                 let width = resize_options.width.unwrap_or(image.width());
                 let height = resize_options.height.unwrap_or(image.height());
-                let dpr = resize_options.effective_dpr();
+                let dpr = resize_options.dpr.unwrap();
 
                 // Resize the image
                 *image = image.resize(
@@ -73,12 +73,17 @@ mod tests {
         ImagePipeline::new(source, destination, "input", "output")
     }
 
-    fn set_opts(pipeline: &mut ImagePipeline, width: u32, height: u32, dpr: f32) {
+    fn set_opts(
+        pipeline: &mut ImagePipeline,
+        width: Option<u32>,
+        height: Option<u32>,
+        dpr: Option<f32>,
+    ) {
         pipeline.options = ProcessingOptions {
             resize: Some(ResizeOptions {
-                width: Some(width),
-                height: Some(height),
-                dpr: Some(dpr),
+                width,
+                height,
+                dpr,
                 ..Default::default()
             }),
         };
@@ -94,7 +99,7 @@ mod tests {
     #[tokio::test]
     async fn test_pipeline_resize_applies() {
         let mut pipeline = create_pipeline();
-        set_opts(&mut pipeline, 50, 50, 1.0);
+        set_opts(&mut pipeline, Some(50), Some(50), Some(1.0));
         verify_base_image_size(&mut pipeline).await;
 
         // Resize the image & check the size
@@ -107,7 +112,7 @@ mod tests {
     #[tokio::test]
     async fn test_pipeline_dpr_resize_applies() {
         let mut pipeline = create_pipeline();
-        set_opts(&mut pipeline, 10, 10, 2.0);
+        set_opts(&mut pipeline, Some(10), Some(10), Some(2.0));
         verify_base_image_size(&mut pipeline).await;
 
         // Resize the image & check the size (10x10 with 2.0 dpr = 20x20)
@@ -120,7 +125,7 @@ mod tests {
     #[tokio::test]
     async fn test_pipeline_dpr_resize_round_applies() {
         let mut pipeline = create_pipeline();
-        set_opts(&mut pipeline, 10, 10, 2.04);
+        set_opts(&mut pipeline, Some(10), Some(10), Some(2.04));
         verify_base_image_size(&mut pipeline).await;
 
         // Resize the image & check the size (10x10 with 2.04 dpr should be round to down = 20x20)
@@ -130,10 +135,23 @@ mod tests {
         assert_eq!(pipeline.image.as_ref().unwrap().height(), 20);
 
         // Resize the image & check the size (10x10 with 2.05 dpr should be round to up = 21x21)
-        set_opts(&mut pipeline, 10, 10, 2.05);
+        set_opts(&mut pipeline, Some(10), Some(10), Some(2.05));
         pipeline.resize().unwrap();
         assert!(pipeline.image.is_some());
         assert_eq!(pipeline.image.as_ref().unwrap().width(), 21);
         assert_eq!(pipeline.image.as_ref().unwrap().height(), 21);
+    }
+
+    #[tokio::test]
+    async fn test_pipeline_dpr_without_resize_options() {
+        let mut pipeline = create_pipeline();
+        set_opts(&mut pipeline, None, None, Some(2.0));
+        verify_base_image_size(&mut pipeline).await;
+
+        // Resize the image & check the size (100x100 with 2.0 dpr = 20x20)
+        pipeline.resize().unwrap();
+        assert!(pipeline.image.is_some());
+        assert_eq!(pipeline.image.as_ref().unwrap().width(), 200);
+        assert_eq!(pipeline.image.as_ref().unwrap().height(), 200);
     }
 }


### PR DESCRIPTION
#9 

This PR introduces native support for **Device Pixel Ratio (DPR)** scaling within the core image pipeline's resize logic.

---

### ✨ What’s Included

- ✅ Add dpr: Option<f32> to ResizeOptions
- ✅ Default dpr to 1.0
- ✅ Resize applies dpr as a multiplier on final target size
- ✅ Validate dpr is between 0.1 and 10.0
- ✅ is_enabled() detects DPR-only configurations
- ✅ Tests for:
  - dpr-only resizing
  - rounding behavior
  - invalid values
  - default behavior (1.0)

---

### 📚 Why This Matters

DPR (aka @2x, @3x scaling) is essential for responsive image delivery, especially on mobile/high-density screens.

By integrating this at the core level:

- Entrypoints (CLI, HTTP) don’t need to re-implement pixel scaling
- Users can scale output dynamically without computing exact dimensions
- This lays the groundwork for future features like srcset generation