### PR TITLE
feat(core): improve naive resize with strategies

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 anyhow = "1.0.97"
 async-trait = "0.1.88"
 bytemuck = "1.22.0"
-clap = "4.5.40"
+clap = { version = "4.5.40", features = ["derive"] }
 image = "0.25.6"
 tokio = { version = "1.44.1", features = ["fs", "macros", "rt", "rt-multi-thread"] }
 webp = "0.2.2"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 anyhow = "1.0.97"
 async-trait = "0.1.88"
 bytemuck = "1.22.0"
+clap = "4.5.40"
 image = "0.25.6"
 tokio = { version = "1.44.1", features = ["fs", "macros", "rt", "rt-multi-thread"] }
 webp = "0.2.2"

--- a/core/src/models/resize_options.rs
+++ b/core/src/models/resize_options.rs
@@ -1,11 +1,21 @@
 use anyhow::{Result, anyhow};
+use clap::ValueEnum;
 use image::imageops::FilterType;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum AspectRatioStrategy {
+    Fit,     // Default: proportional scaling (fit within width/height)
+    Cover,   // Fill entire target size, possibly cropping
+    Contain, // Fit inside target size without cropping, may leave empty space
+    Stretch, // Force image to match exact dimensions (ignore aspect ratio)
+}
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ResizeOptions {
     pub width: Option<u32>,
     pub height: Option<u32>,
-    pub dpr: Option<f32>,
+    pub dpr: f32,
+    pub strategy: AspectRatioStrategy,
     pub filter: FilterType,
 }
 
@@ -14,27 +24,35 @@ impl Default for ResizeOptions {
         Self {
             width: None,
             height: None,
-            dpr: Some(1.0),
+            dpr: 1.0,
+            strategy: AspectRatioStrategy::Fit,
             filter: FilterType::Triangle,
         }
     }
 }
 
 impl ResizeOptions {
-    pub fn new(width: Option<u32>, height: Option<u32>, dpr: Option<f32>) -> Result<Self> {
-        let opts: ResizeOptions = Self {
+    pub fn new(width: Option<u32>, height: Option<u32>) -> Self {
+        ResizeOptions {
             width,
             height,
-            dpr,
             ..Self::default()
-        };
-        opts.validate()?;
-        Ok(opts)
+        }
+    }
+
+    pub fn dpr(mut self, dpr: f32) -> Self {
+        self.dpr = dpr;
+        self
+    }
+
+    pub fn strategy(mut self, strategy: AspectRatioStrategy) -> Self {
+        self.strategy = strategy;
+        self
     }
 
     pub fn is_enabled(&self) -> bool {
         let is_size_modified = self.width.is_some() || self.height.is_some();
-        let is_dpr_modified = matches!(self.dpr, Some(val) if val != 1.0);
+        let is_dpr_modified = self.dpr != 1.0;
         is_size_modified || is_dpr_modified
     }
 
@@ -59,11 +77,29 @@ impl ResizeOptions {
             }
         }
 
-        let dpr = self.dpr.unwrap_or(1.0);
+        let dpr = self.dpr;
         if !(0.1..=10.0).contains(&dpr) {
             return Err(anyhow!(
                 "Resize dpr must be between 0.1 and 10.0 (default is 1.0)"
             ));
+        }
+
+        if !self.is_enabled() {
+            return Ok(());
+        }
+
+        match self.strategy {
+            AspectRatioStrategy::Fit => {
+                return Ok(());
+            }
+            _ => {
+                if self.width.is_none() || self.height.is_none() {
+                    return Err(anyhow!(
+                        "{:?} strategy requires both width and height to be set",
+                        self.strategy
+                    ));
+                }
+            }
         }
 
         Ok(())
@@ -77,7 +113,7 @@ mod tests {
     #[test]
     fn test_default_dpr() {
         let opts = ResizeOptions::default();
-        assert_eq!(opts.dpr, Some(1.0));
+        assert_eq!(opts.dpr, 1.0);
     }
 
     mod is_enabled {
@@ -86,23 +122,23 @@ mod tests {
         #[test]
         fn test_is_enabled() {
             // Full
-            let opts = ResizeOptions::new(Some(800), Some(600), Some(2.0)).unwrap();
+            let opts = ResizeOptions::new(Some(800), Some(600));
             assert!(opts.is_enabled());
 
             // None
-            let opts = ResizeOptions::new(None, None, None).unwrap();
+            let opts = ResizeOptions::new(None, None);
             assert!(!opts.is_enabled());
 
             // Width only
-            let opts = ResizeOptions::new(Some(800), None, None).unwrap();
+            let opts = ResizeOptions::new(Some(800), None);
             assert!(opts.is_enabled());
 
             // Height only
-            let opts = ResizeOptions::new(None, Some(600), None).unwrap();
+            let opts = ResizeOptions::new(None, Some(600));
             assert!(opts.is_enabled());
 
             // DPR only != 1.0
-            let opts = ResizeOptions::new(None, None, Some(2.0)).unwrap();
+            let opts = ResizeOptions::new(None, None).dpr(2.0);
             assert!(opts.is_enabled());
         }
     }
@@ -112,46 +148,103 @@ mod tests {
 
         #[test]
         fn valid_resize_options_pass() {
-            let opts = vec![
-                ResizeOptions::new(Some(800), Some(600), Some(2.0)),
-                ResizeOptions::new(None, None, None),
-                ResizeOptions::new(Some(800), None, Some(2.0)),
-                ResizeOptions::new(None, Some(600), Some(2.0)),
-                ResizeOptions::new(None, None, Some(2.0)),
+            let opts = [
+                ResizeOptions::new(Some(800), Some(600)),
+                ResizeOptions::new(None, None).dpr(2.0),
+                ResizeOptions::new(Some(800), None),
+                ResizeOptions::new(None, Some(600)),
             ];
-            for opt in opts {
-                assert!(opt.is_ok());
+            for (i, opt) in opts.iter().enumerate() {
+                assert!(
+                    opt.validate().is_ok(),
+                    "Failed to validate opts[{}] = {:?}",
+                    i,
+                    opt
+                );
             }
         }
 
         #[test]
         fn invalid_resize_sizes_options_fails() {
             let opts = vec![
-                ResizeOptions::new(Some(0), Some(100), None),
-                ResizeOptions::new(Some(0), None, Some(2.0)),
-                ResizeOptions::new(None, Some(0), Some(2.0)),
-                ResizeOptions::new(Some(100), Some(0), None),
+                ResizeOptions::new(Some(0), Some(100)),
+                ResizeOptions::new(Some(0), None),
+                ResizeOptions::new(None, Some(0)),
+                ResizeOptions::new(Some(100), Some(0)),
             ];
             for opt in opts {
-                assert!(opt.is_err());
+                assert!(opt.validate().is_err());
             }
         }
 
         #[test]
         fn invalid_dpr_fails() {
             let opts = vec![
-                ResizeOptions::new(Some(100), Some(100), Some(0.0)),
-                ResizeOptions::new(Some(100), Some(100), Some(11.0)),
-                ResizeOptions::new(Some(100), Some(100), Some(0.05)),
-                ResizeOptions::new(Some(100), Some(100), Some(42.0)),
+                ResizeOptions::new(Some(100), Some(100)).dpr(0.0),
+                ResizeOptions::new(Some(100), Some(100)).dpr(11.0),
+                ResizeOptions::new(Some(100), Some(100)).dpr(0.05),
+                ResizeOptions::new(Some(100), Some(100)).dpr(42.0),
             ];
 
             for opt in opts {
-                assert!(opt.is_err());
+                assert!(opt.validate().is_err());
                 assert_eq!(
-                    opt.unwrap_err().to_string(),
+                    opt.validate().unwrap_err().to_string(),
                     "Resize dpr must be between 0.1 and 10.0 (default is 1.0)"
                 );
+            }
+        }
+
+        mod aspect_ratio_strategy {
+            use super::*;
+
+            mod fit {
+                use super::*;
+
+                #[test]
+                fn valid_resize_aspect_ratio_fit_strategy() {
+                    let cases = vec![
+                        ResizeOptions::new(Some(800), None),
+                        ResizeOptions::new(None, Some(600)),
+                        ResizeOptions::new(Some(1024), Some(768)),
+                        ResizeOptions::new(Some(500), None).dpr(1.5),
+                        ResizeOptions::new(None, Some(500)).dpr(0.5),
+                        ResizeOptions::new(Some(1200), Some(800)).dpr(2.0),
+                        ResizeOptions::new(None, None).dpr(1.2),
+                        ResizeOptions::new(None, None),
+                        ResizeOptions::new(Some(300), Some(200)).strategy(AspectRatioStrategy::Fit),
+                    ];
+
+                    for (i, opts) in cases.into_iter().enumerate() {
+                        assert!(
+                            opts.validate().is_ok(),
+                            "Fit strategy should accept case #{}: {:?}",
+                            i,
+                            opts
+                        );
+                    }
+                }
+
+                #[test]
+                fn invalid_resize_aspect_ratio_fit_strategy() {
+                    let cases = vec![
+                        ResizeOptions::new(Some(0), None).dpr(1.0),
+                        ResizeOptions::new(None, Some(0)).dpr(1.0),
+                        ResizeOptions::new(None, None).dpr(0.05),
+                        ResizeOptions::new(None, None).dpr(20.0),
+                        ResizeOptions::new(Some(800), None).dpr(0.05),
+                        ResizeOptions::new(None, Some(600)).dpr(20.0),
+                    ];
+
+                    for (i, opts) in cases.into_iter().enumerate() {
+                        assert!(
+                            opts.validate().is_err(),
+                            "Fit strategy should reject case #{}: {:?}",
+                            i,
+                            opts
+                        );
+                    }
+                }
             }
         }
     }

--- a/core/src/models/resize_options.rs
+++ b/core/src/models/resize_options.rs
@@ -26,7 +26,7 @@ impl Default for ResizeOptions {
             height: None,
             dpr: 1.0,
             strategy: AspectRatioStrategy::Fit,
-            filter: FilterType::Triangle,
+            filter: FilterType::Nearest,
         }
     }
 }

--- a/core/src/models/resize_options.rs
+++ b/core/src/models/resize_options.rs
@@ -26,7 +26,7 @@ impl Default for ResizeOptions {
             height: None,
             dpr: 1.0,
             strategy: AspectRatioStrategy::Fit,
-            filter: FilterType::Nearest,
+            filter: FilterType::Triangle, // Default to Triangle for higher-quality resizing
         }
     }
 }

--- a/core/src/models/resize_options.rs
+++ b/core/src/models/resize_options.rs
@@ -246,6 +246,70 @@ mod tests {
                     }
                 }
             }
+
+            mod others {
+                use crate::models::resize_options;
+
+                use super::*;
+                static STRATEGIES: &[resize_options::AspectRatioStrategy] = &[
+                    AspectRatioStrategy::Cover,
+                    AspectRatioStrategy::Contain,
+                    AspectRatioStrategy::Stretch,
+                ];
+                #[test]
+                fn with_width_and_height_defined_should_be_valid_and_enabled() {
+                    let cases = [
+                        Some(1024),
+                        Some(768),
+                        Some(1200),
+                        Some(800),
+                        Some(300),
+                        Some(200),
+                    ];
+
+                    for (i, opts) in cases.chunks(2).enumerate() {
+                        for strategy in STRATEGIES.iter() {
+                            let operation =
+                                ResizeOptions::new(opts[0], opts[1]).strategy(*strategy);
+                            assert!(
+                                operation.validate().is_ok() && operation.is_enabled(),
+                                "{:?} strategy should accept case #{}: {:?}",
+                                strategy,
+                                i,
+                                opts
+                            );
+                        }
+                    }
+                }
+
+                #[test]
+                fn without_width_or_height_should_be_invalid_or_disabled() {
+                    let cases = [
+                        None,
+                        Some(768),
+                        Some(1200),
+                        None,
+                        None,
+                        None,
+                        Some(0),
+                        Some(768),
+                    ];
+
+                    for (i, opts) in cases.chunks(2).enumerate() {
+                        for strategy in STRATEGIES.iter() {
+                            let operation =
+                                ResizeOptions::new(opts[0], opts[1]).strategy(*strategy);
+                            assert!(
+                                operation.validate().is_err() || !operation.is_enabled(),
+                                "{:?} strategy should not accept case #{}: {:?}",
+                                strategy,
+                                i,
+                                opts
+                            );
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/core/src/services/encoding/png.rs
+++ b/core/src/services/encoding/png.rs
@@ -172,26 +172,22 @@ mod tests {
 
         #[test]
         fn test_extension_returns_png() {
-            let encoder = PngEncoder;
-            assert_eq!(encoder.extension(), "png");
+            assert_eq!(PngEncoder.extension(), "png");
         }
 
         #[test]
         fn test_mime_type_returns_correct_value() {
-            let encoder = PngEncoder;
-            assert_eq!(encoder.mime_type(), "image/png");
+            assert_eq!(PngEncoder.mime_type(), "image/png");
         }
 
         #[test]
         fn test_format_returns_png_format() {
-            let encoder = PngEncoder;
-            assert_eq!(encoder.format(), ImageFormat::Png);
+            assert_eq!(PngEncoder.format(), ImageFormat::Png);
         }
 
         #[test]
-        fn test_supports_native_quality_encoding_is_false() {
-            let encoder = PngEncoder;
-            assert!(!encoder.supports_native_quality_encoding());
+        fn test_supports_native_quality_encoding_is_true() {
+            assert!(PngEncoder.supports_native_quality_encoding());
         }
     }
 
@@ -203,17 +199,16 @@ mod tests {
             #[test]
             fn for_quality_levels() {
                 let test_cases = vec![
-                    (Some(95.0), CompressionType::Best),
-                    (Some(90.0), CompressionType::Best),
-                    (Some(89.0), CompressionType::Default),
-                    (Some(75.0), CompressionType::Default),
-                    (Some(40.0), CompressionType::Default),
-                    (Some(39.0), CompressionType::Fast),
-                    (Some(10.0), CompressionType::Fast),
-                    (None, CompressionType::Default), // fallback quality = 75
+                    (Some(100.0), CompressionType::Best, FilterType::Paeth),
+                    (Some(67.0), CompressionType::Best, FilterType::Paeth),
+                    (Some(66.0), CompressionType::Default, FilterType::Sub),
+                    (Some(34.0), CompressionType::Default, FilterType::Sub),
+                    (Some(33.0), CompressionType::Fast, FilterType::NoFilter),
+                    (Some(0.0), CompressionType::Fast, FilterType::NoFilter),
+                    (None, CompressionType::Best, FilterType::Paeth), // fallback quality = 75
                 ];
 
-                for (quality, expected_compression) in test_cases {
+                for (quality, expected_compression, expected_filter) in test_cases {
                     let (compression, filter) = PngEncoder::guess_encoding_params(quality);
                     assert_eq!(
                         compression, expected_compression,
@@ -221,9 +216,9 @@ mod tests {
                         quality
                     );
                     assert_eq!(
-                        filter,
-                        FilterType::Adaptive,
-                        "Filter should always be Adaptive"
+                        filter, expected_filter,
+                        "Filter should be {:?}",
+                        expected_filter
                     );
                 }
             }

--- a/core/src/services/encoding/png.rs
+++ b/core/src/services/encoding/png.rs
@@ -49,23 +49,29 @@ impl ImageEncoder for PngEncoder {
     }
 
     fn supports_native_quality_encoding(&self) -> bool {
-        false
+        true
     }
 }
 
 impl PngEncoder {
     fn guess_encoding_params(quality: Option<f32>) -> (CompressionType, FilterType) {
+        let q = quality.unwrap_or(75.0).round() as u8;
         // Map quality to PNG compression strategy:
         // - High quality → Best compression (slow, small file)
         // - Medium quality → Default
         // - Low quality → Fast (quick, larger file)
-        let compression = match quality.unwrap_or(75.0).round() as u8 {
-            90..=100 => CompressionType::Best,
-            40..=89 => CompressionType::Default,
-            _ => CompressionType::Fast,
+        let compression = match q {
+            0..=33 => CompressionType::Fast,
+            34..=66 => CompressionType::Default,
+            _ => CompressionType::Best,
         };
 
-        let filter = FilterType::Adaptive;
+        let filter = match q {
+            0..=33 => FilterType::NoFilter,
+            34..=66 => FilterType::Sub,
+            _ => FilterType::Paeth,
+        };
+
         (compression, filter)
     }
 

--- a/core/src/services/encoding/png.rs
+++ b/core/src/services/encoding/png.rs
@@ -54,12 +54,19 @@ impl ImageEncoder for PngEncoder {
 }
 
 impl PngEncoder {
+    /// Maps a user-provided "quality" value (0–100) to PNG compression and filter strategies.
+    ///
+    /// Rationale for thresholds:
+    /// - 0..=33   (Low quality):  Use Fast compression and NoFilter for speed, sacrificing file size.
+    /// - 34..=66  (Medium quality): Use Default compression and Sub filter for a balance of speed and size.
+    /// - 67..=100 (High quality):  Use Best compression and Paeth filter for smallest file, slowest encoding.
+    ///
+    /// These ranges are chosen to roughly split the quality scale into three intuitive bands:
+    ///   - 0–33: "I want it fast, don't care about size"
+    ///   - 34–66: "Balance speed and size"
+    ///   - 67–100: "I want the smallest file, even if it's slow"
     fn guess_encoding_params(quality: Option<f32>) -> (CompressionType, FilterType) {
         let q = quality.unwrap_or(75.0).round() as u8;
-        // Map quality to PNG compression strategy:
-        // - High quality → Best compression (slow, small file)
-        // - Medium quality → Default
-        // - Low quality → Fast (quick, larger file)
         let compression = match q {
             0..=33 => CompressionType::Fast,
             34..=66 => CompressionType::Default,

--- a/core/src/services/options/quality.rs
+++ b/core/src/services/options/quality.rs
@@ -16,7 +16,8 @@ impl ImagePipeline<'_> {
             return Ok(());
         }
 
-        let image = self.get_image()?.clone();
+        // Get the image early to fail fast if it's not loaded, before doing expensive operations
+        let image = self.get_image()?;
 
         // Step 3: Check if target encoder supports native quality encoding
         let encoder = self.resolve_encoder()?;
@@ -32,7 +33,7 @@ impl ImagePipeline<'_> {
                 anyhow::anyhow!("[core/quality] No JPEG encoder available for quality optimization")
             })?;
 
-        let encoded = jpeg_encoder.encode(&image, &self.options)?;
+        let encoded = jpeg_encoder.encode(&image.clone(), &self.options)?;
 
         // Step 5: Override the image with the processed one
         // This is a workaround for the fact that we don't have a way to set the quality in the encoder

--- a/core/src/services/options/quality.rs
+++ b/core/src/services/options/quality.rs
@@ -16,6 +16,8 @@ impl ImagePipeline<'_> {
             return Ok(());
         }
 
+        let image = self.get_image()?.clone();
+
         // Step 3: Check if target encoder supports native quality encoding
         let encoder = self.resolve_encoder()?;
         if encoder.supports_native_quality_encoding() {
@@ -23,7 +25,6 @@ impl ImagePipeline<'_> {
         }
 
         // Step 4: Fallback to naive JPEG encoding with quality optimization
-        let image = self.get_image()?.clone();
         let jpeg_encoder = self
             .codec_resolver
             .resolve(ImageFormat::Jpeg)

--- a/core/src/services/options/resize.rs
+++ b/core/src/services/options/resize.rs
@@ -1,6 +1,6 @@
-use image::{imageops::overlay, DynamicImage, RgbaImage};
+use image::{DynamicImage, RgbaImage, imageops::overlay};
 
-use crate::{models::resize_options::AspectRatioStrategy, ImagePipeline};
+use crate::{ImagePipeline, models::resize_options::AspectRatioStrategy};
 
 impl ImagePipeline<'_> {
     pub fn resize(&mut self) -> Result<(), anyhow::Error> {

--- a/core/src/services/options/resize.rs
+++ b/core/src/services/options/resize.rs
@@ -1,4 +1,6 @@
-use crate::ImagePipeline;
+use image::{DynamicImage, RgbaImage, imageops::overlay};
+
+use crate::{ImagePipeline, models::resize_options::AspectRatioStrategy};
 
 impl ImagePipeline<'_> {
     pub fn resize(&mut self) -> Result<(), anyhow::Error> {
@@ -10,14 +12,30 @@ impl ImagePipeline<'_> {
                     .ok_or_else(|| anyhow::anyhow!("[core/resize] Image cannot be loaded"))?;
                 let width = resize_options.width.unwrap_or(image.width());
                 let height = resize_options.height.unwrap_or(image.height());
-                let dpr = resize_options.dpr.unwrap();
+                let dpr = resize_options.dpr;
 
-                // Resize the image
-                *image = image.resize(
-                    (width as f32 * dpr).round() as u32,
-                    (height as f32 * dpr).round() as u32,
-                    resize_options.filter,
-                );
+                let target_w = (width as f32 * dpr).round() as u32;
+                let target_h = (height as f32 * dpr).round() as u32;
+                let filter = resize_options.filter;
+
+                let new_img: DynamicImage = match resize_options.strategy {
+                    AspectRatioStrategy::Fit => image.resize(target_w, target_h, filter),
+
+                    AspectRatioStrategy::Cover => image.resize_to_fill(target_w, target_h, filter),
+
+                    AspectRatioStrategy::Stretch => image.resize_exact(target_w, target_h, filter),
+
+                    AspectRatioStrategy::Contain => {
+                        let scaled = image.resize(target_w, target_h, filter);
+                        let mut shape = RgbaImage::new(target_w, target_h);
+                        let x = (target_w.saturating_sub(shape.width())) / 2;
+                        let y = (target_h.saturating_sub(shape.height())) / 2;
+                        overlay(&mut shape, &scaled, x.into(), y.into());
+                        DynamicImage::ImageRgba8(shape)
+                    }
+                };
+
+                *image = new_img;
             }
         }
         Ok(())
@@ -82,7 +100,7 @@ mod tests {
             resize: Some(ResizeOptions {
                 width,
                 height,
-                dpr,
+                dpr: dpr.unwrap_or(1.0),
                 ..Default::default()
             }),
             quality: None,

--- a/core/src/services/options/resize.rs
+++ b/core/src/services/options/resize.rs
@@ -1,6 +1,6 @@
-use image::{DynamicImage, RgbaImage, imageops::overlay};
+use image::{imageops::overlay, DynamicImage, RgbaImage};
 
-use crate::{ImagePipeline, models::resize_options::AspectRatioStrategy};
+use crate::{models::resize_options::AspectRatioStrategy, ImagePipeline};
 
 impl ImagePipeline<'_> {
     pub fn resize(&mut self) -> Result<(), anyhow::Error> {
@@ -20,16 +20,13 @@ impl ImagePipeline<'_> {
 
                 let new_img: DynamicImage = match resize_options.strategy {
                     AspectRatioStrategy::Fit => image.resize(target_w, target_h, filter),
-
                     AspectRatioStrategy::Cover => image.resize_to_fill(target_w, target_h, filter),
-
                     AspectRatioStrategy::Stretch => image.resize_exact(target_w, target_h, filter),
-
                     AspectRatioStrategy::Contain => {
                         let scaled = image.resize(target_w, target_h, filter);
                         let mut shape = RgbaImage::new(target_w, target_h);
-                        let x = (target_w.saturating_sub(shape.width())) / 2;
-                        let y = (target_h.saturating_sub(shape.height())) / 2;
+                        let x = (target_w.saturating_sub(scaled.width())) / 2;
+                        let y = (target_h.saturating_sub(scaled.height())) / 2;
                         overlay(&mut shape, &scaled, x.into(), y.into());
                         DynamicImage::ImageRgba8(shape)
                     }
@@ -41,6 +38,7 @@ impl ImagePipeline<'_> {
         Ok(())
     }
 }
+
 #[cfg(test)]
 mod tests {
     use crate::ImagePipeline;

--- a/entrypoints/cli/src/main.rs
+++ b/entrypoints/cli/src/main.rs
@@ -1,9 +1,8 @@
 use adapters::resolver::AdapterResolver;
 use anyhow::Result;
 use clap::Parser;
-use wiot_core::models::options::ResizeOptions;
 use wiot_core::models::quality_options::QualityOptions;
-use wiot_core::models::resize_options::AspectRatioStrategy;
+use wiot_core::models::resize_options::{AspectRatioStrategy, ResizeOptions};
 use wiot_core::{ImagePipeline, models::options::ProcessingOptions};
 
 #[derive(Parser, Debug)]

--- a/entrypoints/cli/src/main.rs
+++ b/entrypoints/cli/src/main.rs
@@ -1,7 +1,9 @@
 use adapters::resolver::AdapterResolver;
 use anyhow::Result;
 use clap::Parser;
+use wiot_core::models::options::ResizeOptions;
 use wiot_core::models::quality_options::QualityOptions;
+use wiot_core::models::resize_options::AspectRatioStrategy;
 use wiot_core::{ImagePipeline, models::options::ProcessingOptions};
 
 #[derive(Parser, Debug)]
@@ -19,6 +21,22 @@ struct CliArgs {
     /// Image quality (1-100, default: 80)
     #[arg(short, long)]
     quality: Option<u8>,
+
+    /// Width
+    #[arg(short = 'W', long)]
+    width: Option<u32>,
+
+    /// Height
+    #[arg(short = 'H', long)]
+    height: Option<u32>,
+
+    /// DPR
+    #[arg(long)]
+    dpr: Option<f32>,
+
+    /// Aspect ratio strategy (Fit, Cover, Contain, Stretch, default: Fit)
+    #[arg(short, long, value_enum)]
+    aspect_ratio: Option<AspectRatioStrategy>,
 }
 
 #[tokio::main]
@@ -36,9 +54,30 @@ async fn main() -> Result<()> {
         None
     };
 
+    // Resize options
+    let resize_options = if args.width.is_some()
+        || args.height.is_some()
+        || args.dpr.is_some()
+        || args.aspect_ratio.is_some()
+    {
+        let mut ro = ResizeOptions::new(args.width, args.height);
+
+        if let Some(dpr_val) = args.dpr {
+            ro = ro.dpr(dpr_val);
+        }
+        if let Some(strat) = args.aspect_ratio {
+            ro = ro.strategy(strat);
+        }
+
+        Some(ro)
+    } else {
+        None
+    };
+
     // Create processing options
     let options = ProcessingOptions {
         quality: quality_options,
+        resize: resize_options,
         ..Default::default()
     };
 


### PR DESCRIPTION
#10 
chore(core): add clap to derive aspect-ratio strategies for CLIs args

feat(entrypoint/cli): support width, height, dpr, aspect_ratio operations