### PR TITLE
fix(cli): wire --format flag to ProcessingOptions.format

### DIFF
--- a/core/src/pipeline/helpers.rs
+++ b/core/src/pipeline/helpers.rs
@@ -55,3 +55,90 @@ impl ImagePipeline<'_> {
             .ok_or_else(|| anyhow::anyhow!("[core/pipeline] Image not loaded"))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::any::Any;
+    use std::sync::Arc;
+
+    use anyhow::Result;
+    use async_trait::async_trait;
+    use image::{DynamicImage, ImageFormat};
+
+    use crate::ImagePipeline;
+    use crate::models::options::{FormatOptions, ProcessingOptions};
+    use crate::services::io::{FileDestination, FileSource};
+
+    struct MockSource;
+
+    #[async_trait]
+    impl FileSource for MockSource {
+        async fn read(&self, _path: &str) -> Result<DynamicImage> {
+            Ok(DynamicImage::new_rgb8(1, 1))
+        }
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+    }
+
+    struct MockDestination;
+
+    #[async_trait]
+    impl FileDestination for MockDestination {
+        async fn write(&self, _path: &str, _data: &[u8]) -> Result<()> {
+            Ok(())
+        }
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+    }
+
+    fn create_pipeline_with_format(
+        output: &str,
+        format: Option<FormatOptions>,
+    ) -> ImagePipeline<'static> {
+        let source = Arc::new(MockSource);
+        let destination = Arc::new(MockDestination);
+        let mut pipeline = ImagePipeline::new(source, destination, "input.jpg", output.to_string());
+        pipeline.options = ProcessingOptions {
+            format,
+            ..Default::default()
+        };
+        pipeline
+    }
+
+    #[test]
+    fn resolve_encoder_errors_on_format_extension_mismatch() {
+        let pipeline = create_pipeline_with_format(
+            "out.webp",
+            Some(FormatOptions::new(Some(ImageFormat::Png)).unwrap()),
+        );
+        let result = pipeline.resolve_encoder();
+        match result {
+            Err(e) => assert!(
+                e.to_string().contains("does not match"),
+                "Expected 'does not match' error, got: {}",
+                e
+            ),
+            Ok(_) => panic!("Expected error for format/extension mismatch"),
+        }
+    }
+
+    #[test]
+    fn resolve_encoder_succeeds_when_format_matches_extension() {
+        let pipeline = create_pipeline_with_format(
+            "out.webp",
+            Some(FormatOptions::new(Some(ImageFormat::WebP)).unwrap()),
+        );
+        let result = pipeline.resolve_encoder();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn resolve_encoder_falls_back_to_extension_when_no_format() {
+        let pipeline = create_pipeline_with_format("out.png", None);
+        let result = pipeline.resolve_encoder();
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().format(), ImageFormat::Png);
+    }
+}

--- a/entrypoints/cli/Cargo.toml
+++ b/entrypoints/cli/Cargo.toml
@@ -8,4 +8,5 @@ wiot_core = { path = "../../core" }
 adapters = { path = "../../adapters" }
 anyhow = "1.0.97"
 clap = { version = "4.5.34", features = ["derive"] }
+image = "0.25.6"
 tokio = "1.44.1"

--- a/entrypoints/cli/src/args/format.rs
+++ b/entrypoints/cli/src/args/format.rs
@@ -1,4 +1,7 @@
+use anyhow::{anyhow, Result};
 use clap::Args;
+use image::ImageFormat;
+use wiot_core::models::options::FormatOptions;
 
 #[derive(Args, Debug)]
 pub struct FormatArgs {
@@ -16,4 +19,159 @@ pub struct FormatArgs {
     /// This flag is incompatible with the "format" option.
     #[arg(long, conflicts_with_all = &["format"])]
     pub auto_format: bool,
+}
+
+impl FormatArgs {
+    pub fn get(&self) -> Result<Option<FormatOptions>> {
+        match &self.format {
+            None => Ok(None),
+            Some(fmt) => {
+                let image_format = ImageFormat::from_extension(fmt).ok_or_else(|| {
+                    anyhow!(
+                        "[cli/format] Unsupported format '{}'. Supported formats: \
+                             jpeg, jpg, png, webp, avif, gif",
+                        fmt
+                    )
+                })?;
+                let opts = FormatOptions::new(Some(image_format))?;
+                Ok(Some(opts))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_args_get_none() {
+        let args = FormatArgs {
+            format: None,
+            auto_format: false,
+        };
+        let result = args.get().unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_format_args_get_webp() {
+        let args = FormatArgs {
+            format: Some("webp".to_string()),
+            auto_format: false,
+        };
+        let opts = args.get().unwrap().unwrap();
+        assert_eq!(opts.format, Some(ImageFormat::WebP));
+    }
+
+    #[test]
+    fn test_format_args_get_jpeg() {
+        let args = FormatArgs {
+            format: Some("jpeg".to_string()),
+            auto_format: false,
+        };
+        let opts = args.get().unwrap().unwrap();
+        assert_eq!(opts.format, Some(ImageFormat::Jpeg));
+    }
+
+    #[test]
+    fn test_format_args_get_jpg() {
+        let args = FormatArgs {
+            format: Some("jpg".to_string()),
+            auto_format: false,
+        };
+        let opts = args.get().unwrap().unwrap();
+        assert_eq!(opts.format, Some(ImageFormat::Jpeg));
+    }
+
+    #[test]
+    fn test_format_args_get_png() {
+        let args = FormatArgs {
+            format: Some("png".to_string()),
+            auto_format: false,
+        };
+        let opts = args.get().unwrap().unwrap();
+        assert_eq!(opts.format, Some(ImageFormat::Png));
+    }
+
+    #[test]
+    fn test_format_args_get_avif() {
+        let args = FormatArgs {
+            format: Some("avif".to_string()),
+            auto_format: false,
+        };
+        let opts = args.get().unwrap().unwrap();
+        assert_eq!(opts.format, Some(ImageFormat::Avif));
+    }
+
+    #[test]
+    fn test_format_args_get_gif() {
+        let args = FormatArgs {
+            format: Some("gif".to_string()),
+            auto_format: false,
+        };
+        let opts = args.get().unwrap().unwrap();
+        assert_eq!(opts.format, Some(ImageFormat::Gif));
+    }
+
+    #[test]
+    fn test_format_args_get_invalid_unknown() {
+        let args = FormatArgs {
+            format: Some("xyz".to_string()),
+            auto_format: false,
+        };
+        let result = args.get();
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("[cli/format] Unsupported format 'xyz'"));
+    }
+
+    #[test]
+    fn test_format_args_get_invalid_unsupported() {
+        let args = FormatArgs {
+            format: Some("bmp".to_string()),
+            auto_format: false,
+        };
+        let result = args.get();
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Unsupported output format"));
+    }
+
+    #[test]
+    fn test_format_args_get_case_insensitive() {
+        let cases = vec![
+            ("WEBP", ImageFormat::WebP),
+            ("WebP", ImageFormat::WebP),
+            ("PNG", ImageFormat::Png),
+            ("Png", ImageFormat::Png),
+            ("JPEG", ImageFormat::Jpeg),
+            ("JPG", ImageFormat::Jpeg),
+            ("AVIF", ImageFormat::Avif),
+            ("GIF", ImageFormat::Gif),
+        ];
+        for (input, expected) in cases {
+            let args = FormatArgs {
+                format: Some(input.to_string()),
+                auto_format: false,
+            };
+            let result = args.get();
+            assert!(
+                result.is_ok(),
+                "Expected '{}' to be accepted, got: {}",
+                input,
+                result.unwrap_err()
+            );
+            assert_eq!(
+                result.unwrap().unwrap().format,
+                Some(expected),
+                "Failed for input: {}",
+                input
+            );
+        }
+    }
 }

--- a/entrypoints/cli/src/args/format.rs
+++ b/entrypoints/cli/src/args/format.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use clap::Args;
 use image::ImageFormat;
 use wiot_core::models::options::FormatOptions;
@@ -122,10 +122,12 @@ mod tests {
         };
         let result = args.get();
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("[cli/format] Unsupported format 'xyz'"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("[cli/format] Unsupported format 'xyz'")
+        );
     }
 
     #[test]
@@ -136,10 +138,12 @@ mod tests {
         };
         let result = args.get();
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Unsupported output format"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Unsupported output format")
+        );
     }
 
     #[test]

--- a/entrypoints/cli/src/main.rs
+++ b/entrypoints/cli/src/main.rs
@@ -67,7 +67,7 @@ async fn main() -> Result<()> {
         blur: args.blur.get(),
         background: args.background.get(),
         image_adjustments: args.image_adjustments.get(),
-        ..Default::default()
+        format: args.format.get()?,
     };
 
     // Create a new ImagePipeline instance with options


### PR DESCRIPTION
## Summary

The `--format` CLI flag was parsed by clap but never mapped to `ProcessingOptions.format`. The output format was always inferred from the output file extension, silently ignoring the user's explicit format choice.

## Changes

- Add `.get()` method to `FormatArgs` converting `Option<String>` to `Option<FormatOptions>`
- Map `format: args.format.get()` explicitly in `main.rs` `ProcessingOptions` construction
- Add unit tests for format parsing, invalid format handling, and mismatch scenarios

## How to test

```bash
# Should produce WebP
cargo run -p cli -- -i ./tests/assets/Pencil_drawing_of_a_girl_in_ecstasy.jpg --format webp -o /tmp/test.webp -q 80

# Should error (format/extension mismatch)
cargo run -p cli -- -i ./tests/assets/Pencil_drawing_of_a_girl_in_ecstasy.jpg --format png -o /tmp/test.webp -q 80

# Should fall back to extension inference (no regression)
cargo run -p cli -- -i ./tests/assets/Pencil_drawing_of_a_girl_in_ecstasy.jpg -o /tmp/test.webp -q 80
```

## Checklist

- [x] `just test --all` passes
- [x] `just lint` passes
- [x] `just format` passes